### PR TITLE
Feature/step 3

### DIFF
--- a/src/main/scala/example/Game.scala
+++ b/src/main/scala/example/Game.scala
@@ -4,33 +4,26 @@ import scala.util.Random
 
 object Game {
   def play(): Unit = {
-    println("Enter 0 for Rock, 1 for Paper and 2 for Scissors")
+    println("Enter 0 for Rock, 1 for Paper or 2 for Scissors")
 
     val input = scala.io.StdIn.readLine()
-    if (input != "0" & input != "1" & input != "2") {
+
+    val playerMove = Move.fromString(input)
+    if (playerMove.isEmpty) {
       println("Invalid input")
       return
     }
+    val botMove = Move.fromInt(Random.nextInt(3))
 
-    val bot = new Random().nextInt(3)
-
-    println(s"YOU: ${codeToSign(input.toInt)} - ME: ${codeToSign(bot)}")
-    println(outcome(input.toInt, bot))
+    println(s"YOU: ${playerMove.get} - ME: ${botMove.get}")
+    println(outcome(playerMove.get, botMove.get))
   }
 
-  def outcome(playerMove: Int, botMove: Int): String = {
+  def outcome(playerMove: Move.EnumVal, botMove: Move.EnumVal): String = {
     (playerMove, botMove) match {
       case (playerMove, botMove) if playerMove == botMove => "DRAW"
-      case (0, 2) | (1, 0) | (2, 1) => "YOU WIN"
+      case (Move.Rock, Move.Scissors) | (Move.Scissors, Move.Paper) | (Move.Paper, Move.Rock) => "YOU WIN"
       case _ => "YOU LOSE"
-    }
-  }
-
-  def codeToSign(i: Int): String = {
-    i match {
-      case 0 => "ROCK"
-      case 1 => "PAPER"
-      case 2 => "SCISSOR"
     }
   }
 

--- a/src/main/scala/example/Game.scala
+++ b/src/main/scala/example/Game.scala
@@ -8,15 +8,19 @@ object Game {
 
     val input = scala.io.StdIn.readLine()
 
-    val playerMove = Move.fromString(input)
-    if (playerMove.isEmpty) {
-      println("Invalid input")
-      return
+    Move.fromString(input) match {
+      case Some(playerMove) => {
+        val botMove = generateBotMove()
+        println(s"YOU: ${playerMove} - ME: ${botMove}")
+        println(outcome(playerMove, botMove))
+      }
+      case None => println("Invalid input")
     }
-    val botMove = Move.fromInt(Random.nextInt(3))
 
-    println(s"YOU: ${playerMove.get} - ME: ${botMove.get}")
-    println(outcome(playerMove.get, botMove.get))
+  }
+
+  def generateBotMove(): Move.EnumVal = {
+    Random.shuffle(List(Move.Rock, Move.Paper, Move.Scissors)).head
   }
 
   def outcome(playerMove: Move.EnumVal, botMove: Move.EnumVal): String = {

--- a/src/main/scala/example/Move.scala
+++ b/src/main/scala/example/Move.scala
@@ -22,6 +22,5 @@ object Move {
       case "2" => Some(Move.Scissors)
       case _ => None
     }
+  }
 }
-
-

--- a/src/main/scala/example/Move.scala
+++ b/src/main/scala/example/Move.scala
@@ -6,15 +6,6 @@ object Move {
     case object Paper extends EnumVal
     case object Scissors extends EnumVal
 
-  def fromInt(i: Int): Option[Move.EnumVal] = {
-    i match {
-      case 0 => Some(Move.Rock)
-      case 1 => Some(Move.Paper)
-      case 2 => Some(Move.Scissors)
-      case _ => None
-    }
-  }
-
   def fromString(i: String): Option[Move.EnumVal] = {
     i match {
       case "0" => Some(Move.Rock)

--- a/src/main/scala/example/Move.scala
+++ b/src/main/scala/example/Move.scala
@@ -1,0 +1,27 @@
+package example
+
+object Move {
+    sealed trait EnumVal
+    case object Rock extends EnumVal
+    case object Paper extends EnumVal
+    case object Scissors extends EnumVal
+
+  def fromInt(i: Int): Option[Move.EnumVal] = {
+    i match {
+      case 0 => Some(Move.Rock)
+      case 1 => Some(Move.Paper)
+      case 2 => Some(Move.Scissors)
+      case _ => None
+    }
+  }
+
+  def fromString(i: String): Option[Move.EnumVal] = {
+    i match {
+      case "0" => Some(Move.Rock)
+      case "1" => Some(Move.Paper)
+      case "2" => Some(Move.Scissors)
+      case _ => None
+    }
+}
+
+


### PR DESCRIPTION
@Cardu 
io ho implementato gli enum come nell'esempio linkato allo step 3 ([questo](https://underscore.io/blog/posts/2014/09/03/enumerations.html)), dove vengono presentati così
```
object WeekDay {
  sealed trait EnumVal
  case object Mon extends EnumVal
  case object Tue extends EnumVal
  case object Wed extends EnumVal
  case object Thu extends EnumVal
  case object Fri extends EnumVal
}
```
mentre nella soluzione sono svolti così

```
sealed trait Move
object Move {
  case object Rock extends Move
  case object Paper extends Move
  case object Scissors extends Move
}
```

questo fa si che io abbia dovuto chiamarli com `Move.Rock` mentre nella soluzione vengono chiamati come `Rock`.

Qual è la differenza in questi due approcci e quando ha senso usare uno invece dell'altro?